### PR TITLE
Fix invalid buffer sizing causing crash.

### DIFF
--- a/MyPiUI/Drawing/DrawBuffer.cs
+++ b/MyPiUI/Drawing/DrawBuffer.cs
@@ -30,7 +30,7 @@ public class DrawBuffer
         _bitsPerPixel = bitsPerPixel;
         _bytesPerPixel =  _bitsPerPixel / 8;
         
-        _backBuffer = new byte[width * height * bitsPerPixel];
+        _backBuffer = new byte[width * height * _bytesPerPixel];
         
         _dirtyRegions = new List<Rectangle>();
         

--- a/MyPiUI/Drawing/RenderTargets/FrameBufferRenderTarget.cs
+++ b/MyPiUI/Drawing/RenderTargets/FrameBufferRenderTarget.cs
@@ -10,7 +10,7 @@ public class FrameBufferRenderTarget : IRenderTarget, IDisposable
     private readonly MemoryMappedFile _frameBufferMemoryMap;
     private readonly MemoryMappedViewAccessor _frameBufferAccessor;
     
-    private int _expectedBufferSize;
+    private readonly int _expectedBufferSize;
     
     public FrameBufferRenderTarget(string frameBufferDevicePath)
     {

--- a/MyPiUI/Drawing/RenderTargets/FrameBufferRenderTarget.cs
+++ b/MyPiUI/Drawing/RenderTargets/FrameBufferRenderTarget.cs
@@ -10,6 +10,8 @@ public class FrameBufferRenderTarget : IRenderTarget, IDisposable
     private readonly MemoryMappedFile _frameBufferMemoryMap;
     private readonly MemoryMappedViewAccessor _frameBufferAccessor;
     
+    private int _expectedBufferSize;
+    
     public FrameBufferRenderTarget(string frameBufferDevicePath)
     {
         if (string.IsNullOrWhiteSpace(frameBufferDevicePath))
@@ -30,6 +32,8 @@ public class FrameBufferRenderTarget : IRenderTarget, IDisposable
 
         var bytesPerPixel = frameBufferInfo.Depth / 8;
         var frameBufferSize = frameBufferInfo.Width * frameBufferInfo.VirtualHeight * bytesPerPixel;
+
+        _expectedBufferSize = frameBufferSize;
         
         _frameBufferStream = new FileStream(frameBufferDevicePath, 
             FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
@@ -42,6 +46,11 @@ public class FrameBufferRenderTarget : IRenderTarget, IDisposable
     
     public void SwapBuffer(byte[] buffer)
     {
+        if (buffer.Length != _expectedBufferSize)
+        {
+            throw new Exception($"Invalid buffer size. Expected size of '{_expectedBufferSize}' got '{buffer.Length}'.");
+        }
+        
         unsafe
         {
             fixed (byte* src = buffer)


### PR DESCRIPTION
## Changes
- Fixed incorrect buffer size calculation for Raylib & FrameBuffer render targets.
- Added exception to catch invalid buffer sizes.